### PR TITLE
Previous month day issue fixed;

### DIFF
--- a/library/src/main/java/com/dt/composedatepicker/ComposeCalendar.kt
+++ b/library/src/main/java/com/dt/composedatepicker/ComposeCalendar.kt
@@ -98,6 +98,7 @@ fun ComposeCalendar(
         LaunchedEffect(key1 = selectedYear, key2 = selectedMonth) {
             calendarDate.set(Calendar.YEAR, selectedYear)
             calendarDate.set(Calendar.MONTH, selectedMonth.index)
+            calendarDate.set(Calendar.DAY_OF_MONTH,1) //For example, if the date is 30 march and we click february, then it shows 2March because february does not have 30 days, so we set default day to 1
             selectedDate = calendarDate.time
         }
         LaunchedEffect(key1 = selectedYear) {


### PR DESCRIPTION
For example, if the date is 30 march and we click february, then it shows 2March because february does not have 30 days, so we set default day to 1