### PR TITLE
Make Month view type configurable on OneScreenMonthYear

### DIFF
--- a/library/src/main/java/com/dt/composedatepicker/CalendarMonthViewOneColumn.kt
+++ b/library/src/main/java/com/dt/composedatepicker/CalendarMonthViewOneColumn.kt
@@ -35,6 +35,7 @@ fun CalendarMonthViewOneColumn(
         .fillMaxHeight(0.85f)
         .fillMaxWidth()
         .padding(10.dp),
+    monthViewType: MonthViewType?,
 ) {
 
     LazyColumn(
@@ -55,7 +56,8 @@ fun CalendarMonthViewOneColumn(
                 setShowMonths = setShowMonths,
                 showOnlyMonth = showOnlyMonth,
                 themeColor = themeColor,
-                unselectedColor = unselectedColor
+                unselectedColor = unselectedColor,
+                monthViewType = monthViewType
             )
         }
     }
@@ -76,6 +78,7 @@ fun MonthItemOneColumn(
     showOnlyMonth: Boolean,
     themeColor: Color,
     unselectedColor: Color,
+    monthViewType: MonthViewType?,
 ) {
     val enabled = checkDate(
         minYear = minYear,
@@ -87,6 +90,15 @@ fun MonthItemOneColumn(
     )
 
     val monthAsNumber = String.format("%02d", index.plus(1))
+
+    val monthText: String = when (monthViewType) {
+        MonthViewType.ONLY_MONTH -> month.name.uppercase()
+        MonthViewType.ONLY_NUMBER -> monthAsNumber
+        MonthViewType.BOTH_NUMBER_AND_MONTH -> month.name.uppercase() + " " + "(${
+            monthAsNumber
+        })"
+        else -> month.name.uppercase()
+    }
 
     Box(modifier = Modifier
         .padding(vertical = 6.dp)
@@ -101,7 +113,7 @@ fun MonthItemOneColumn(
             }
         }) {
         Text(
-            text = monthAsNumber,
+            text = monthText,
             fontSize = if (month.name == selectedMonth) 35.sp else 30.sp,
             color = if (enabled && month.name == selectedMonth) themeColor
             else if (enabled) unselectedColor

--- a/library/src/main/java/com/dt/composedatepicker/ComposeCalendar.kt
+++ b/library/src/main/java/com/dt/composedatepicker/ComposeCalendar.kt
@@ -143,7 +143,8 @@ fun ComposeCalendar(
                     showOnlyMonth = calendarType == CalendarType.ONLY_MONTH,
                     themeColor = themeColor,
                     unselectedColor = unselectedColor,
-                    setYear = setYear
+                    setYear = setYear,
+                    monthViewType = monthViewType
                 )
             } else {
                 Crossfade(targetState = showMonths) {
@@ -162,7 +163,8 @@ fun ComposeCalendar(
                                     monthList = monthList,
                                     showOnlyMonth = calendarType == CalendarType.ONLY_MONTH,
                                     themeColor = themeColor,
-                                    unselectedColor = unselectedColor
+                                    unselectedColor = unselectedColor,
+                                    monthViewType = monthViewType
                                 )
                             } else {
                                 CalendarMonthView(

--- a/library/src/main/java/com/dt/composedatepicker/OneScreenMonthYear.kt
+++ b/library/src/main/java/com/dt/composedatepicker/OneScreenMonthYear.kt
@@ -24,6 +24,7 @@ fun OneScreenMonthYear(
     themeColor: Color,
     unselectedColor: Color,
     setYear: (Int) -> Unit,
+    monthViewType: MonthViewType?,
 ) {
     Row() {
         CalendarMonthViewOneColumn(
@@ -43,6 +44,7 @@ fun OneScreenMonthYear(
                 .fillMaxHeight(0.85f)
                 .fillMaxWidth(0.5f)
                 .padding(vertical = 10.dp),
+            monthViewType = monthViewType,
         )
         CalendarYearView(
             selectedYear = selectedYear,


### PR DESCRIPTION
This PR makes the OneScreenMonthYear composable modifiable via the `monthViewType`, allowing it to display the month as either numbers or 3-letter name.

![image](https://user-images.githubusercontent.com/5341492/208910995-d421b50c-2d0b-4eb1-95b1-a8a21cfe3b77.png)
